### PR TITLE
Wire OG/Twitter link-preview metadata (use the brand og-image)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,42 @@
 import '@/styles/globals.css';
 
 import { Analytics } from '@vercel/analytics/react';
+import { Metadata } from 'next';
 import { Kanit, Roboto } from 'next/font/google';
 import { ReactNode } from 'react';
+
+const SITE_URL = 'https://www.zack.land';
+const SITE_DESCRIPTION = "Zack Greenbauer's Portfolio and Sandbox";
+
+export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
+  description: SITE_DESCRIPTION,
+  openGraph: {
+    title: 'Zack Greenbauer',
+    description: SITE_DESCRIPTION,
+    url: SITE_URL,
+    siteName: 'zack.land',
+    type: 'website',
+    images: [
+      {
+        url: '/brand/og-image.png',
+        width: 1200,
+        height: 630,
+        alt: 'Zack Greenbauer — Portfolio and Sandbox',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Zack Greenbauer',
+    description: SITE_DESCRIPTION,
+    images: ['/brand/og-image.png'],
+  },
+  icons: {
+    icon: '/favicon.ico',
+    apple: '/brand/apple-touch-icon.png',
+  },
+};
 
 const kanit = Kanit({
   subsets: ['latin'],

--- a/public/brand/README.md
+++ b/public/brand/README.md
@@ -43,15 +43,21 @@ Icon (matcap head): `/tmp/brandkit/head.html` — Three.js r128 loading the repo
 `mainMatcap.jpg` with the site's matcap shader. Both rendered with headless Chrome at 2×
 (`--allow-file-access-from-files --use-angle=swiftshader` for the WebGL head) and downscaled with `sips`.
 
-## Optional: wire the OG image into the site
+## Link previews (wired in `app/layout.tsx`)
 
-In `app/layout.tsx` (or per-page `metadata`), add:
+The OG/Twitter metadata + icons are wired into the root layout's `metadata`
+export, so link-preview crawlers (iMessage, Slack, X, Facebook, LinkedIn)
+serve `og-image.png`:
 
 ```ts
-export const metadata = {
-  metadataBase: new URL('https://zack.land'),
-  openGraph: { images: ['/brand/og-image.png'] },
+export const metadata: Metadata = {
+  metadataBase: new URL('https://www.zack.land'),
+  openGraph: { /* title, description, url, siteName, type */
+    images: [{ url: '/brand/og-image.png', width: 1200, height: 630 }],
+  },
   twitter: { card: 'summary_large_image', images: ['/brand/og-image.png'] },
   icons: { icon: '/favicon.ico', apple: '/brand/apple-touch-icon.png' },
 };
 ```
+
+`favicon.ico` is intentionally the original (unchanged); only the apple-touch icon points at the kit.


### PR DESCRIPTION
## Why

Tested the prod link preview: `https://www.zack.land` only serves `<title>` + `description` — **no `og:image`**. The brand `og-image.png` shipped in #23 but was never referenced in the site's `metadata`, so texting/sharing the link showed a bare preview.

## What

Adds OG/Twitter metadata + icons to the root layout (`app/layout.tsx`):
- `metadataBase` → absolute image URLs (`https://www.zack.land/brand/og-image.png`)
- `openGraph` (title/description/url/siteName/type + 1200×630 image)
- `twitter` `summary_large_image` card + image
- `icons`: **original `/favicon.ico` (unchanged)** + `/brand/apple-touch-icon.png`

## Verification (local, Node 22)
- `next build` / `tsc` / `next lint` → all exit 0
- Built HTML head emits:
  - `og:image = https://www.zack.land/brand/og-image.png` (+ width/height/alt)
  - `twitter:card = summary_large_image`, `twitter:image`
  - `apple-touch-icon` → `/brand/apple-touch-icon.png`

Once merged, sharing the link in iMessage/Slack/X/LinkedIn shows the brand card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)