### PR TITLE
Harden + instrument contact email route (diagnose missing deliveries)

### DIFF
--- a/app/api/email/route.ts
+++ b/app/api/email/route.ts
@@ -2,6 +2,9 @@ import { createTransport } from 'nodemailer';
 
 import { ContactFormData } from '../../(root)/contact/Form';
 
+// nodemailer needs the Node.js runtime (not Edge).
+export const runtime = 'nodejs';
+
 const transporter = createTransport({
   host: process.env.EMAIL_HOST,
   auth: {
@@ -13,14 +16,37 @@ const transporter = createTransport({
   },
 });
 
+const json = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
 export async function POST(request: Request): Promise<Response> {
+  // Surface any missing mail config (logged, never returned to the client).
+  const missing = (
+    [
+      'EMAIL_HOST',
+      'EMAIL_USER',
+      'EMAIL_PASS',
+      'FROM_EMAIL',
+      'TO_EMAIL',
+    ] as const
+  ).filter((key) => !process.env[key]);
+  if (missing.length) {
+    console.error('[contact] missing env vars:', missing.join(', '));
+    return json({ error: 'Email is not configured' }, 500);
+  }
+
   const { name, email, message }: ContactFormData = await request.json();
 
-  await transporter.sendMail({
-    from: `zack.land --> ${name} <${process.env.FROM_EMAIL}>`,
-    to: `zack.land <${process.env.TO_EMAIL}>`,
-    subject: 'New Message - zack.land',
-    html: `
+  try {
+    const info = await transporter.sendMail({
+      from: `zack.land --> ${name} <${process.env.FROM_EMAIL}>`,
+      to: `zack.land <${process.env.TO_EMAIL}>`,
+      replyTo: `${name} <${email}>`,
+      subject: 'New Message - zack.land',
+      html: `
       <html>
         <body>
           <small> From: <b>${name}</b> &lt;${email}&gt; </small>
@@ -30,9 +56,27 @@ export async function POST(request: Request): Promise<Response> {
         </body>
       </html>
     `,
-  });
+    });
 
-  return new Response(JSON.stringify({ message: 'Email sent successfully' }), {
-    headers: { 'Content-Type': 'application/json' },
-  });
+    // These fields tell us exactly what the SMTP server did with the message —
+    // the difference between "accepted & delivered" and "accepted but bounced".
+    console.log('[contact] sendMail result:', {
+      messageId: info.messageId,
+      response: info.response,
+      accepted: info.accepted,
+      rejected: info.rejected,
+    });
+
+    if (info.rejected?.length) {
+      return json(
+        { error: 'Recipient rejected', rejected: info.rejected },
+        502,
+      );
+    }
+
+    return json({ message: 'Email sent successfully' });
+  } catch (error) {
+    console.error('[contact] sendMail failed:', error);
+    return json({ error: 'Failed to send email' }, 500);
+  }
 }


### PR DESCRIPTION
## Why

You tested the contact form and didn't get the email. The prod log shows `POST /api/email` returned **200** — so nodemailer's `sendMail` resolved and the SMTP server **accepted** the message; it's failing *downstream* (spam filter / from-address / recipient). The route logged nothing about delivery, so there was no way to see what happened.

## What

- **Logs the delivery result** — `messageId`, `response`, `accepted`, `rejected` — so we can tell "accepted & delivered" from "accepted but filtered/bounced".
- **Real error handling** — `try/catch` → `500` on send failure, `502` on rejected recipients, so the form shows its error state instead of a false "sent".
- **Missing-env guard** — logs which of `EMAIL_HOST/USER/PASS`, `FROM_EMAIL`, `TO_EMAIL` are unset and returns 500.
- **`replyTo`** = the visitor's email (replies go to them, not to the SMTP user).
- **`runtime = 'nodejs'`** (nodemailer can't run on Edge).

No change to delivery behavior — this makes the failure *visible*.

## Verification
- `next build` exit 0, `tsc` exit 0.
- No unit-test harness exists for API routes (repo has cypress e2e only) — verified by build + a live re-test: after merge, submit the form once and the function logs will show `accepted`/`rejected`/`response`, pinpointing the cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)