### PR TITLE
SEO essentials: robots.txt, sitemap.xml, canonical URLs, Person JSON-LD

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,14 +8,46 @@ import { ReactNode } from 'react';
 const SITE_URL = 'https://www.zack.land';
 const SITE_DESCRIPTION = "Zack Greenbauer's Portfolio and Sandbox";
 
+const SOCIAL_LINKS = [
+  'https://github.com/Greenbauer',
+  'https://www.linkedin.com/in/greenbauer',
+  'https://www.instagram.com/zgreenbauer',
+  'https://www.behance.net/greenbauer',
+];
+
+const personJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Person',
+  name: 'Zack Greenbauer',
+  url: SITE_URL,
+  description: SITE_DESCRIPTION,
+  sameAs: SOCIAL_LINKS,
+};
+
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
   description: SITE_DESCRIPTION,
+  keywords: [
+    'Zack Greenbauer',
+    'portfolio',
+    'web apps',
+    'digital art',
+    '3D',
+    'three.js',
+    'creative developer',
+    'designer',
+  ],
+  authors: [{ name: 'Zack Greenbauer', url: SITE_URL }],
+  creator: 'Zack Greenbauer',
+  alternates: {
+    canonical: './',
+  },
   openGraph: {
     title: 'Zack Greenbauer',
     description: SITE_DESCRIPTION,
     url: SITE_URL,
     siteName: 'zack.land',
+    locale: 'en_US',
     type: 'website',
     images: [
       {
@@ -60,6 +92,10 @@ export default function RootLayout({ children }: RootLayoutProps) {
       <body
         className={`${kanit.variable} ${roboto.variable} flex min-h-[100svh] w-full justify-center bg-black`}
       >
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(personJsonLd) }}
+        />
         {children}
         <Analytics />
       </body>

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,14 @@
+import { MetadataRoute } from 'next';
+
+const SITE_URL = 'https://www.zack.land';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,20 @@
+import { MetadataRoute } from 'next';
+
+const SITE_URL = 'https://www.zack.land';
+
+const routes = [
+  '',
+  '/portfolio',
+  '/portfolio/web-apps',
+  '/portfolio/art',
+  '/portfolio/miscellaneous',
+  '/contact',
+];
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return routes.map((route) => ({
+    url: `${SITE_URL}${route}`,
+    changeFrequency: 'monthly',
+    priority: route === '' ? 1 : 0.7,
+  }));
+}


### PR DESCRIPTION
## What

Standard SEO foundations, all no-keys / low-risk:

- **`app/robots.ts`** → `/robots.txt` allowing all crawlers + pointing to the sitemap
- **`app/sitemap.ts`** → `/sitemap.xml` listing all 6 routes
- **Metadata** (`app/layout.tsx`): per-page **canonical** URLs (`alternates.canonical`), `keywords`, `authors`/`creator`, OpenGraph `locale`
- **Person JSON-LD** structured data — name + `sameAs` (GitHub/LinkedIn/Instagram/Behance) for Google's knowledge panel

## Verification (local, Node 22)
- `next build` exit 0, `tsc` exit 0
- Build emits `/robots.txt` and `/sitemap.xml` routes
- Rendered HTML confirmed to include: per-page `<link rel="canonical">`, `<meta name="keywords">`, and the `application/ld+json` Person block

Independent of the contact-email and BotID work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)