### PR TITLE
Hide reCAPTCHA v3 badge + add required disclosure

### DIFF
--- a/app/(root)/contact/Form.tsx
+++ b/app/(root)/contact/Form.tsx
@@ -7,6 +7,10 @@ import FormFields, { Field } from '@/components/FormFields';
 import { getRecaptchaToken } from '@/utils/recaptcha-client';
 import { post } from '@/utils/request';
 
+// Shown only when reCAPTCHA is active — required by Google's terms when the
+// badge is hidden (see styles/globals.css .grecaptcha-badge).
+const recaptchaEnabled = !!process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY;
+
 export type ContactFormData = {
   name: string;
   email: string;
@@ -69,34 +73,57 @@ export default function Form() {
   };
 
   return (
-    <form
-      className="-mt-2 flex gap-1 md:gap-3"
-      onSubmit={handleSubmit(handleOnSubmit)}
-    >
-      <div className="flex flex-wrap gap-x-6">
-        <FormFields fields={fields1} register={register} errors={errors} />
-      </div>
-      <FormFields fields={fields2} register={register} errors={errors} />
-      <div className="flex flex-col items-center gap-3">
-        {!isSubmitSuccessful && (
-          <Button
-            type="submit"
-            disabled={!isDirty || !isValid}
-            showSpinner={isSubmitting}
+    <>
+      <form
+        className="-mt-2 flex gap-1 md:gap-3"
+        onSubmit={handleSubmit(handleOnSubmit)}
+      >
+        <div className="flex flex-wrap gap-x-6">
+          <FormFields fields={fields1} register={register} errors={errors} />
+        </div>
+        <FormFields fields={fields2} register={register} errors={errors} />
+        <div className="flex flex-col items-center gap-3">
+          {!isSubmitSuccessful && (
+            <Button
+              type="submit"
+              disabled={!isDirty || !isValid}
+              showSpinner={isSubmitting}
+            >
+              Submit
+            </Button>
+          )}
+          {isSubmitted && (
+            <div className="flex w-full justify-center text-center">
+              {isSubmitSuccessful ? (
+                <small className="text-cyan">Your message has been sent</small>
+              ) : (
+                <small className="text-yellow">An error has occurred </small>
+              )}
+            </div>
+          )}
+        </div>
+      </form>
+      {recaptchaEnabled && (
+        <small className="mt-4 block">
+          This site is protected by reCAPTCHA and the Google{' '}
+          <a
+            href="https://policies.google.com/privacy"
+            target="_blank"
+            rel="noreferrer"
           >
-            Submit
-          </Button>
-        )}
-        {isSubmitted && (
-          <div className="flex w-full justify-center text-center">
-            {isSubmitSuccessful ? (
-              <small className="text-cyan">Your message has been sent</small>
-            ) : (
-              <small className="text-yellow">An error has occurred </small>
-            )}
-          </div>
-        )}
-      </div>
-    </form>
+            Privacy Policy
+          </a>{' '}
+          and{' '}
+          <a
+            href="https://policies.google.com/terms"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Terms of Service
+          </a>{' '}
+          apply.
+        </small>
+      )}
+    </>
   );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -136,3 +136,10 @@
     @apply absolute top-0 left-0 w-full h-full;
   }
 }
+
+/* reCAPTCHA v3 badge — hidden per Google's terms; the contact form shows the
+   required "protected by reCAPTCHA" disclosure instead. Also stops the badge
+   lingering across client-side navigation after the contact page loads it. */
+.grecaptcha-badge {
+  visibility: hidden;
+}


### PR DESCRIPTION
## What you reported
- The reCAPTCHA badge appears on **every** page, not just contact.
- You want the little corner badge hidden.

## Root cause
The script only loads on `/contact` (confirmed: `0` script tags in every other route's served HTML). But when the contact page loads, Google injects the `.grecaptcha-badge` element into `<body>` — and since the site is a SPA, that badge **lingers across client-side navigation**, so it visually shows on other pages in the same session.

## Fix
- **`styles/globals.css`** — hide `.grecaptcha-badge` globally (removes the lingering corner icon everywhere).
- **Contact form** — add Google's required *"This site is protected by reCAPTCHA and the Google Privacy Policy and Terms of Service apply."* disclosure (with links), shown only when reCAPTCHA is active. Google's terms require this text whenever the badge is hidden.

No change to where the script loads — still `/contact` only.

## Test plan
- `npm run build` → 12/12 pages, `/contact` builds
- `npx tsc --noEmit` clean, `npx next lint` no errors, `stylelint` clean
- Post-deploy: badge gone on all pages; disclosure text under the contact form

🤖 Generated with [Claude Code](https://claude.com/claude-code)