### PR TITLE
Move reCAPTCHA disclosure to the contact-page footer

### DIFF
--- a/app/(root)/contact/Form.tsx
+++ b/app/(root)/contact/Form.tsx
@@ -7,10 +7,6 @@ import FormFields, { Field } from '@/components/FormFields';
 import { getRecaptchaToken } from '@/utils/recaptcha-client';
 import { post } from '@/utils/request';
 
-// Shown only when reCAPTCHA is active — required by Google's terms when the
-// badge is hidden (see styles/globals.css .grecaptcha-badge).
-const recaptchaEnabled = !!process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY;
-
 export type ContactFormData = {
   name: string;
   email: string;
@@ -73,57 +69,34 @@ export default function Form() {
   };
 
   return (
-    <>
-      <form
-        className="-mt-2 flex gap-1 md:gap-3"
-        onSubmit={handleSubmit(handleOnSubmit)}
-      >
-        <div className="flex flex-wrap gap-x-6">
-          <FormFields fields={fields1} register={register} errors={errors} />
-        </div>
-        <FormFields fields={fields2} register={register} errors={errors} />
-        <div className="flex flex-col items-center gap-3">
-          {!isSubmitSuccessful && (
-            <Button
-              type="submit"
-              disabled={!isDirty || !isValid}
-              showSpinner={isSubmitting}
-            >
-              Submit
-            </Button>
-          )}
-          {isSubmitted && (
-            <div className="flex w-full justify-center text-center">
-              {isSubmitSuccessful ? (
-                <small className="text-cyan">Your message has been sent</small>
-              ) : (
-                <small className="text-yellow">An error has occurred </small>
-              )}
-            </div>
-          )}
-        </div>
-      </form>
-      {recaptchaEnabled && (
-        <small className="mt-4 block">
-          This site is protected by reCAPTCHA and the Google{' '}
-          <a
-            href="https://policies.google.com/privacy"
-            target="_blank"
-            rel="noreferrer"
+    <form
+      className="-mt-2 flex gap-1 md:gap-3"
+      onSubmit={handleSubmit(handleOnSubmit)}
+    >
+      <div className="flex flex-wrap gap-x-6">
+        <FormFields fields={fields1} register={register} errors={errors} />
+      </div>
+      <FormFields fields={fields2} register={register} errors={errors} />
+      <div className="flex flex-col items-center gap-3">
+        {!isSubmitSuccessful && (
+          <Button
+            type="submit"
+            disabled={!isDirty || !isValid}
+            showSpinner={isSubmitting}
           >
-            Privacy Policy
-          </a>{' '}
-          and{' '}
-          <a
-            href="https://policies.google.com/terms"
-            target="_blank"
-            rel="noreferrer"
-          >
-            Terms of Service
-          </a>{' '}
-          apply.
-        </small>
-      )}
-    </>
+            Submit
+          </Button>
+        )}
+        {isSubmitted && (
+          <div className="flex w-full justify-center text-center">
+            {isSubmitSuccessful ? (
+              <small className="text-cyan">Your message has been sent</small>
+            ) : (
+              <small className="text-yellow">An error has occurred </small>
+            )}
+          </div>
+        )}
+      </div>
+    </form>
   );
 }

--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -5,6 +5,10 @@ import { usePathname } from 'next/navigation';
 
 import SocialLinks from './SocialLinks';
 
+// Shown only when reCAPTCHA is active — required by Google's terms when the
+// badge is hidden (see styles/globals.css .grecaptcha-badge).
+const recaptchaEnabled = !!process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY;
+
 function DefaultText() {
   return (
     <h6>
@@ -21,7 +25,32 @@ function DefaultText() {
 }
 
 function ContactPageText() {
-  return <h6>Please fill out this form. Ill will respond as soon as I can.</h6>;
+  return (
+    <>
+      <h6>Please fill out this form. Ill will respond as soon as I can.</h6>
+      {recaptchaEnabled && (
+        <small className="mt-4 block">
+          This site is protected by reCAPTCHA and the Google{' '}
+          <a
+            href="https://policies.google.com/privacy"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Privacy Policy
+          </a>{' '}
+          and{' '}
+          <a
+            href="https://policies.google.com/terms"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Terms of Service
+          </a>{' '}
+          apply.
+        </small>
+      )}
+    </>
+  );
 }
 
 export default function Footer() {


### PR DESCRIPTION
Per request: move the "protected by reCAPTCHA" line from below the form to **under the footer's contact-page text** ("Please fill out this form…").

- **`components/Footer/index.tsx`** — `ContactPageText` now renders the disclosure (same `<small>` styling, same links, same `NEXT_PUBLIC_RECAPTCHA_SITE_KEY` gating) under the existing `<h6>`. Only shows on `/contact`.
- **`app/(root)/contact/Form.tsx`** — disclosure removed; form reverts to a plain `<form>`.

Styling unchanged — identical `<small className="mt-4 block">` + cyan links. Build/tsc/lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)