### PR TITLE
Fix reCAPTCHA disclosure stacking in the footer

### DIFF
--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -25,8 +25,11 @@ function DefaultText() {
 }
 
 function ContactPageText() {
+  // Wrapped in a single block so the disclosure stacks UNDER the heading and
+  // inherits its alignment — the footer's text container is a flex row, so a
+  // bare fragment would lay the two out side by side.
   return (
-    <>
+    <div>
       <h6>Please fill out this form. Ill will respond as soon as I can.</h6>
       {recaptchaEnabled && (
         <small className="mt-4 block">
@@ -49,7 +52,7 @@ function ContactPageText() {
           apply.
         </small>
       )}
-    </>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Problem
The reCAPTCHA disclosure rendered **beside** the "Please fill out this form…" heading instead of under it. The footer's text container is a `flex` row, so `ContactPageText` returning the `<h6>` and `<small>` as a bare fragment made them two side-by-side flex items.

## Fix
Wrap both in a single block `<div>` → one flex item, heading and disclosure stack vertically and inherit the container's alignment (right on desktop, centered on mobile).

## Verification
Headless render of `/contact` (reCAPTCHA enabled), confirmed:
- **Desktop (1280px):** disclosure directly under the heading, both right-aligned to the same edge.
- **Mobile (390px):** both centered and stacked.

tsc / eslint / build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)