### PR TITLE
Enable Submit as soon as the contact form is valid

### DIFF
--- a/app/(root)/contact/Form.tsx
+++ b/app/(root)/contact/Form.tsx
@@ -45,13 +45,17 @@ export default function Form() {
     trigger,
     formState: {
       errors,
+      touchedFields,
       isDirty,
       isValid,
       isSubmitting,
       isSubmitted,
       isSubmitSuccessful,
     },
-  } = useForm<ContactFormData>({ mode: 'onBlur' });
+    // onChange keeps isValid live so Submit enables as soon as the form is
+    // valid — without waiting for the last field to blur. Error text is still
+    // gated on touchedFields (see FormFields), so it only shows after blur.
+  } = useForm<ContactFormData>({ mode: 'onChange' });
 
   const handleOnSubmit = async (data: ContactFormData) => {
     try {
@@ -74,9 +78,19 @@ export default function Form() {
       onSubmit={handleSubmit(handleOnSubmit)}
     >
       <div className="flex flex-wrap gap-x-6">
-        <FormFields fields={fields1} register={register} errors={errors} />
+        <FormFields
+          fields={fields1}
+          register={register}
+          errors={errors}
+          touchedFields={touchedFields}
+        />
       </div>
-      <FormFields fields={fields2} register={register} errors={errors} />
+      <FormFields
+        fields={fields2}
+        register={register}
+        errors={errors}
+        touchedFields={touchedFields}
+      />
       <div className="flex flex-col items-center gap-3">
         {!isSubmitSuccessful && (
           <Button

--- a/components/FormFields.tsx
+++ b/components/FormFields.tsx
@@ -14,12 +14,14 @@ type FormFieldsProps = {
   fields: Field[];
   register: UseFormRegister<any>;
   errors: FieldErrors;
+  touchedFields: Partial<Record<string, boolean>>;
 };
 
 export default function FormFields({
   fields,
   register,
   errors,
+  touchedFields,
 }: FormFieldsProps) {
   const validation: Validation = (type: string) => {
     if (type === 'email') {
@@ -56,8 +58,12 @@ export default function FormFields({
             )}
             <div className="flex h-6 w-full justify-end text-right">
               <small className="py-1 text-yellow">
-                {errors[name]?.type === 'required' && 'required'}
-                {errors[name]?.type === 'pattern' && 'invalid'}
+                {touchedFields[name] &&
+                  errors[name]?.type === 'required' &&
+                  'required'}
+                {touchedFields[name] &&
+                  errors[name]?.type === 'pattern' &&
+                  'invalid'}
               </small>
             </div>
           </div>

--- a/cypress/e2e/contact-form.cy.ts
+++ b/cypress/e2e/contact-form.cy.ts
@@ -1,0 +1,27 @@
+export default describe('Contact form Submit button', () => {
+  beforeEach(() => {
+    cy.visit('http://localhost:3000/contact');
+  });
+
+  it('enables Submit once valid, without blurring the last field', () => {
+    cy.get('form button[type="submit"]').should('be.disabled');
+
+    cy.get('input[name="name"]').type('Zachary Greenbauer');
+    cy.get('input[name="email"]').type('zach@example.com');
+    // Type into the last field and deliberately do NOT blur it.
+    cy.get('textarea[name="message"]').type('Hello there');
+
+    // Still focused on the message field — the button must already be enabled.
+    cy.focused().should('have.attr', 'name', 'message');
+    cy.get('form button[type="submit"]').should('not.be.disabled');
+  });
+
+  it('shows a field error only after blur, not while typing', () => {
+    cy.get('input[name="email"]').type('not-an-email');
+    // While the field is still focused, no error text yet.
+    cy.contains('small', 'invalid').should('not.exist');
+
+    cy.get('input[name="email"]').blur();
+    cy.contains('small', 'invalid').should('be.visible');
+  });
+});


### PR DESCRIPTION
## Problem (confirmed)
The Submit button stayed grayed out until you **unfocused** the last field, even when the form was already valid. Cause: the form used react-hook-form `mode: 'onBlur'`, so `isValid` (which drives `disabled={!isDirty || !isValid}`) only recomputed on blur.

## Fix
- **`mode: 'onChange'`** — `isValid` now updates live, so Submit enables the moment the form is valid, no blur needed.
- **Gate error text on `touchedFields`** — without this, `onChange` would flash "invalid" on the email field while you type. Now errors still only show after a field is blurred (identical to before). Required a `touchedFields` prop on `FormFields`.

## Verification (Cypress, ran locally — 2 passing)
- `enables Submit once valid, without blurring the last field` — types all fields, asserts focus is still on the textarea and the button is **not** disabled.
- `shows a field error only after blur, not while typing` — invalid email shows no error while focused, shows "invalid" after blur.

(The repo's CI is the Vercel build, which doesn't run Cypress — test was run locally; result above.)

tsc / eslint / build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)